### PR TITLE
Make remembered values observable, add `rememberObservable`

### DIFF
--- a/@zapp/core/src/index.ts
+++ b/@zapp/core/src/index.ts
@@ -6,6 +6,7 @@ export {
   setApplicationImplementation as __setApplicationImplementation,
 } from './Application.js'
 export { remember } from './working_tree/effects/remember.js'
+export { rememberObservable } from './working_tree/effects/rememberObservable.js'
 export { rememberLauncherForResult } from './working_tree/effects/rememberLauncherForResult.js'
 export { registerCrownEventHandler } from './working_tree/effects/registerCrownEventHandler.js'
 export { registerGestureEventHandler, GestureType } from './working_tree/effects/registerGestureEventHandler.js'

--- a/@zapp/core/src/working_tree/effects/RememberedMutableValue.ts
+++ b/@zapp/core/src/working_tree/effects/RememberedMutableValue.ts
@@ -8,6 +8,9 @@ export class RememberedMutableValue<T> extends RememberedValue<T> {
   private _animation?: Animation<unknown>
 
   /** @internal */
+  public _observer?: (previous: T, current: T) => void
+
+  /** @internal */
   get animation() {
     return this._animation
   }
@@ -54,6 +57,10 @@ export class RememberedMutableValue<T> extends RememberedValue<T> {
         }
       } else if (oldValue !== newValue) {
         WorkingTree.queueUpdate(this.context.parent!)
+
+        // invoke observer only if node is in active tree, otherwise the assignment is delegated to
+        // the node in active tree, which should trigger its observer
+        this._observer?.(oldValue, newValue)
       }
     }
   }

--- a/@zapp/core/src/working_tree/effects/remember.ts
+++ b/@zapp/core/src/working_tree/effects/remember.ts
@@ -1,52 +1,6 @@
-import { findRelativePath } from '../../utils.js'
-import { RememberNode } from '../RememberNode.js'
-import { ViewNode } from '../ViewNode.js'
-import { WorkingTree } from '../WorkingTree.js'
 import { RememberedMutableValue } from './RememberedMutableValue.js'
-import { Animation, AnimationType } from './animation/Animation.js'
-import { TimingAnimation } from './animation/TimingAnimation.js'
+import { rememberObservable } from './rememberObservable.js'
 
 export function remember<T>(value: T): RememberedMutableValue<T> {
-  const current = WorkingTree.current as ViewNode
-  const context = current.remember()
-
-  let savedRemembered: RememberedMutableValue<T> | null = null
-
-  const restoredState = WorkingTree.root.savedState?.tryFindingValue?.(context)
-
-  if (restoredState !== undefined) {
-    value = restoredState.value as T
-  } else {
-    const path = findRelativePath(context.path, current.rememberedContext?.path)?.concat(context.id)
-    if (path !== null && path !== undefined) {
-      const rememberedNode = current.rememberedContext?.getNodeFromPath(path) ?? null
-
-      if (rememberedNode instanceof RememberNode && rememberedNode.remembered instanceof RememberedMutableValue) {
-        savedRemembered = rememberedNode.remembered
-        // TODO: investigate context switching in remembered values more
-        savedRemembered.switchContext(context)
-      }
-    }
-  }
-
-  const result = savedRemembered === null ? new RememberedMutableValue(value, context) : savedRemembered
-
-  if (restoredState !== undefined && restoredState.animationData !== undefined) {
-    let anim: Animation<unknown> | null = null
-
-    if (restoredState.animationData.type === AnimationType.Timing) {
-      anim = TimingAnimation.restore(restoredState.animationData)
-    }
-
-    if (anim !== null) {
-      // when restoring animation from saved state, assign directly
-      anim.rememberedValue = result
-      result.animation = anim as Animation<T>
-    }
-  }
-
-  context.remembered = result
-  current.children.push(context)
-
-  return result
+  return rememberObservable(value)
 }

--- a/@zapp/core/src/working_tree/effects/rememberObservable.ts
+++ b/@zapp/core/src/working_tree/effects/rememberObservable.ts
@@ -1,0 +1,56 @@
+import { findRelativePath } from '../../utils.js'
+import { RememberNode } from '../RememberNode.js'
+import { ViewNode } from '../ViewNode.js'
+import { WorkingTree } from '../WorkingTree.js'
+import { RememberedMutableValue } from './RememberedMutableValue.js'
+import { Animation, AnimationType } from './animation/Animation.js'
+import { TimingAnimation } from './animation/TimingAnimation.js'
+
+export function rememberObservable<T>(
+  value: T,
+  observer?: (previous: T, current: T) => void
+): RememberedMutableValue<T> {
+  const current = WorkingTree.current as ViewNode
+  const context = current.remember()
+
+  let savedRemembered: RememberedMutableValue<T> | null = null
+
+  const restoredState = WorkingTree.root.savedState?.tryFindingValue?.(context)
+
+  if (restoredState !== undefined) {
+    value = restoredState.value as T
+  } else {
+    const path = findRelativePath(context.path, current.rememberedContext?.path)?.concat(context.id)
+    if (path !== null && path !== undefined) {
+      const rememberedNode = current.rememberedContext?.getNodeFromPath(path) ?? null
+
+      if (rememberedNode instanceof RememberNode && rememberedNode.remembered instanceof RememberedMutableValue) {
+        savedRemembered = rememberedNode.remembered
+        // TODO: investigate context switching in remembered values more
+        savedRemembered.switchContext(context)
+      }
+    }
+  }
+
+  const result = savedRemembered === null ? new RememberedMutableValue(value, context) : savedRemembered
+
+  if (restoredState !== undefined && restoredState.animationData !== undefined) {
+    let anim: Animation<unknown> | null = null
+
+    if (restoredState.animationData.type === AnimationType.Timing) {
+      anim = TimingAnimation.restore(restoredState.animationData)
+    }
+
+    if (anim !== null) {
+      // when restoring animation from saved state, assign directly
+      anim.rememberedValue = result
+      result.animation = anim as Animation<T>
+    }
+  }
+
+  result._observer = observer
+  context.remembered = result
+  current.children.push(context)
+
+  return result
+}


### PR DESCRIPTION
Closes https://github.com/j-piasecki/zapp-framework/issues/22

Makes every remembered value observalble
Adds `rememberObservable`
Makes `remember` to be alias for `rememberObservable` but without passing observer